### PR TITLE
updated conditionals for permission boundary reference in roles

### DIFF
--- a/terraform/modules/ecs/locals.tf
+++ b/terraform/modules/ecs/locals.tf
@@ -8,5 +8,5 @@ locals {
   task_execution_role_name  = "${var.iam_prefix}-${var.app}-ecs-task-exection-role-${terraform.workspace}"
   task_role_name            = "${var.iam_prefix}-${var.app}-ecs-task-role-${terraform.workspace}"
   ecs_log_policy            = "${var.iam_prefix}-${var.app}-ecs-log-policy-${terraform.workspace}"
-  permission_boundary_arn   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/PermissionBoundary_PowerUser"
+  permission_boundary_arn   = terraform.workspace == "dev" || terraform == "qa" ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/PermissionBoundary_PowerUser" : null
 }


### PR DESCRIPTION
this is based on tier. prod accounts don't have permission boundaries. 